### PR TITLE
Fix for Nette on Mac

### DIFF
--- a/PhpStorm Protocol.app/Contents/bin/parse_url.sh
+++ b/PhpStorm Protocol.app/Contents/bin/parse_url.sh
@@ -1,5 +1,6 @@
 #!/bin/sh
 URL="$1"
+URL=$(echo "$URL" | sed "s#%2F#/#g")
 REGEX="^pstorm://open/\?url=file://(.*)&line=(.*)$"
 
 if [[ $URL =~ $REGEX ]]; then

--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ Installing on Mac
 2. go to cloned folder
 2. copy folder ```PhpStorm Protocol.app``` to ```/Applications/``` folder
 3. delete cloned folder
+4. go to PhpStorm Menu: Tools → Create Command-Line Launcher and create it
 
 Installing on Windows
 =====================


### PR DESCRIPTION
Make the launcher work with Nette framework's Tracy, which does escaping by default.
