### PR TITLE
Remove unnecessary slash

### DIFF
--- a/LinCastor.md
+++ b/LinCastor.md
@@ -6,7 +6,7 @@ Since PhpStormProtocol doesn't work as expected on OS X 10.9 (Mavericks), then I
 2. unpack and move to __Applications__ folder
 3. create new protocol handler using configuration from below:
 ![LinCastor Configuration](LinCastorConfig.png)
-4. specify `pstorm://open/?url=file://%f&line=%l` in your debugger configuration (e.g. in the `xdebug.file_link_format` setting in the `php.ini`)
+4. specify `pstorm://open?url=file://%f&line=%l` in your debugger configuration (e.g. in the `xdebug.file_link_format` setting in the `php.ini`)
 5. you maybe need to use different file and line placeholders (instead of `%f` and `%l`) depending on which debugger you're configuring:
  * `%F` and `%L` - for [In-Portal Debugger](http://www.in-portal.org/)
  * `%file` and `%line` - for [Nette Debugger](http://pla.nette.org/en/how-open-files-in-ide-from-debugger)

--- a/PhpStorm Protocol (Win)/run_editor.js
+++ b/PhpStorm Protocol (Win)/run_editor.js
@@ -17,7 +17,7 @@ var settings = {
 
 // don't change anything below this line, unless you know what you're doing
 var	url = WScript.Arguments(0),
-	match = /^pstorm:\/\/open\/\?url=file:\/\/(.+)&line=(\d+)$/.exec(url),
+	match = /^pstorm:\/\/open\?url=file:\/\/(.+)&line=(\d+)$/.exec(url),
 	project = '',
 	editor = '"C:\\' + (settings.x64 ? 'Program Files (x86)' : 'Program Files') + '\\JetBrains\\' + settings.folder_name + '\\bin\\PhpStorm.exe"';
 

--- a/PhpStorm Protocol.app/Contents/bin/parse_url.sh
+++ b/PhpStorm Protocol.app/Contents/bin/parse_url.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
 URL="$1"
-REGEX="^pstorm://open/\?url=file://(.*)&line=(.*)$"
+REGEX="^pstorm://open\?url=file://(.*)&line=(.*)$"
 
 if [[ $URL =~ $REGEX ]]; then
 	/usr/local/bin/pstorm "${BASH_REMATCH[1]}:${BASH_REMATCH[2]}"

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ This app allows to use ```pstorm://``` protocol to open a file in a [PhpStorm ID
 
 Following string must be specified as an editor in your app:
 ```bash
-pstorm://open/?url=file://%f&line=%l
+pstorm://open?url=file://%f&line=%l
 ```
 If something doesn't work, then feel free to [submit an issue](https://github.com/aik099/PhpStormProtocol/issues/new) on GitHub.
 


### PR DESCRIPTION
See https://github.com/symfony/symfony/blob/master/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php#L99-L102:

textmate: `txmt://open?url=file://%f&line=%l`
macvim: `mvim://open?url=file://%f&line=%l`
emacs: `emacs://open?url=file://%f&line=%l`
sublime: `subl://open?url=file://%f&line=%l`