### PR TITLE
Add support for the PhpStorm Mac scheme

### DIFF
--- a/PhpStorm Protocol (Win)/run_editor.js
+++ b/PhpStorm Protocol (Win)/run_editor.js
@@ -17,7 +17,7 @@ var settings = {
 
 // don't change anything below this line, unless you know what you're doing
 var	url = WScript.Arguments(0),
-	match = /^phpstorm:\/\/open\?url=file:\/\/(.+)&line=(\d+)$/.exec(url),
+	match = /^phpstorm:\/\/open\?(url=file:\/\/|file=)(.+)&line=(\d+)$/.exec(url),
 	project = '',
 	editor = '"C:\\' + (settings.x64 ? 'Program Files (x86)' : 'Program Files') + '\\JetBrains\\' + settings.folder_name + '\\bin\\PhpStorm.exe"';
 
@@ -25,7 +25,7 @@ if (match) {
 
 	var	shell = new ActiveXObject('WScript.Shell'),
 		file_system = new ActiveXObject('Scripting.FileSystemObject'),
-		file = decodeURIComponent(match[1]).replace(/\+/g, ' '),
+		file = decodeURIComponent(match[2]).replace(/\+/g, ' '),
 		search_path = file.replace(/\//g, '\\');
 
 	if (settings.projects_basepath != '' && settings.projects_path_alias != '') {
@@ -47,7 +47,7 @@ if (match) {
 
 	editor += ' --line %line% "%file%"';
 
-	var command = editor.replace(/%line%/g, match[2])
+	var command = editor.replace(/%line%/g, match[3])
 						.replace(/%file%/g, file)
 						.replace(/%project%/g, project)
 						.replace(/\//g, '\\');

--- a/PhpStorm Protocol.app/Contents/bin/parse_url.sh
+++ b/PhpStorm Protocol.app/Contents/bin/parse_url.sh
@@ -1,7 +1,7 @@
 #!/bin/sh
 URL="$1"
-REGEX="^phpstorm://open\?url=file://(.*)&line=(.*)$"
+REGEX="^phpstorm://open\?(url=file://|file=)(.*)&line=(.*)$"
 
 if [[ $URL =~ $REGEX ]]; then
-	/usr/local/bin/pstorm "${BASH_REMATCH[1]}:${BASH_REMATCH[2]}"
+	/usr/local/bin/pstorm "${BASH_REMATCH[2]}:${BASH_REMATCH[3]}"
 fi

--- a/README.md
+++ b/README.md
@@ -10,6 +10,12 @@ Following string must be specified as an editor in your app:
 ```bash
 phpstorm://open?url=file://%f&line=%l
 ```
+
+Alternative syntax is supported for cross-platform compatibility with PhPStorm 8+ (Mac version)
+```bash
+phpstorm://open?file=%f&line=%l
+```
+
 If something doesn't work, then feel free to [submit an issue](https://github.com/aik099/PhpStormProtocol/issues/new) on GitHub.
 
 


### PR DESCRIPTION
PhpStorm 8 (Mac) provided native support for the "phpstorm:" protocol. However, they implemented a different format for the the URL.

PhpStorm Mac uses: phpstorm://open?file=@file&line=@line
This handler uses phpstorm://open?url=file://@file&line=@line

symfony/symfony#21712 is going to change the default format to be the Macintosh format.

This PR contains the necessary modifications to support both formats simultaneously. This would standardize the system so that you would not need two different configurations if you are working on different platforms (i.e. Windows vs Mac)