### PR TITLE
total compatibility x64 windows

### DIFF
--- a/PhpStorm Protocol (Win)/run_editor.js
+++ b/PhpStorm Protocol (Win)/run_editor.js
@@ -19,7 +19,7 @@ var settings = {
 var	url = WScript.Arguments(0),
 	match = /^phpstorm:\/\/open\/?\?(url=file:\/\/|file=)(.+)&line=(\d+)$/.exec(url),
 	project = '',
-	editor = '"C:\\' + (settings.x64 ? 'Program Files' : 'Program Files (x86)') + '\\JetBrains\\' + settings.folder_name + '\\bin\\phpstorm.exe"';
+	editor = '"C:\\' + (settings.x64 ? 'Program Files' : 'Program Files (x86)') + '\\JetBrains\\' + settings.folder_name + (settings.x64 ? '\\bin\\phpstorm64.exe' : '\\bin\\phpstorm.exe')+'"';
 
 if (match) {
 


### PR DESCRIPTION
Before it fails because there are 2 files. You can't open phptorm in 64 bits if you not execute phpstorm64.exe

