### PR TITLE
Update run_editor.reg

### DIFF
--- a/PhpStorm Protocol (Win)/run_editor.reg
+++ b/PhpStorm Protocol (Win)/run_editor.reg
@@ -5,4 +5,4 @@ REGEDIT4
 "URL Protocol"=""
 
 [HKEY_CLASSES_ROOT\phpstorm\shell\open\command]
-@="wscript \"C:\\Program Files\\PhpStorm Protocol (Win)\\run_editor.js\" \"%1\" //E:JSCript"
+@="wscript \"C:\\Program Files\\PhpStorm Protocol (Win)\\run_editor.js\" \"%1\" //E:JScript"

--- a/PhpStorm Protocol (Win)/run_editor.reg
+++ b/PhpStorm Protocol (Win)/run_editor.reg
@@ -5,4 +5,4 @@ REGEDIT4
 "URL Protocol"=""
 
 [HKEY_CLASSES_ROOT\phpstorm\shell\open\command]
-@="wscript \"C:\\Program Files\\PhpStorm Protocol (Win)\\run_editor.js\" \"%1\""
+@="wscript \"C:\\Program Files\\PhpStorm Protocol (Win)\\run_editor.js\" \"%1\" //E:JSCript"


### PR DESCRIPTION
Add parameter to wscript to force use of JSCript engine on Windows in case .js files are assigned to different handler in user's system. This eliminates the need of redefining handler or additional registry fixes
fixes #27