### PR TITLE
Update to documentation and run_editor.js

### DIFF
--- a/PhpStorm Protocol (Win)/run_editor.js
+++ b/PhpStorm Protocol (Win)/run_editor.js
@@ -9,7 +9,7 @@ var settings = {
     folder_name: '<phpstorm_folder_name>',
 
     // Set to window title (only text after dash sign), that you see, when switching to running PhpStorm instance
-    window_title: '<phpstorm_folder_name>',
+    window_title: '<phpstorm_window_title>',
 
     // In case your file is mapped via a network share and paths do not match.
     // eg. /var/www will can replaced with Y:/

--- a/PhpStorm Protocol (Win)/run_editor.js
+++ b/PhpStorm Protocol (Win)/run_editor.js
@@ -6,10 +6,10 @@ var settings = {
     x64: true,
 
     // Set to folder name, where PhpStorm was installed to (e.g. 'PhpStorm')
-    folder_name: '<PhpStorm x.y.z folder name where the phpstorm executable has been installed>',
+    folder_name: '<phpstorm_folder_name>',
 
     // Set to window title (only text after dash sign), that you see, when switching to running PhpStorm instance
-    window_title: 'PhpStorm 2017.1.4',
+    window_title: '<phpstorm_folder_name>',
 
     // In case your file is mapped via a network share and paths do not match.
     // eg. /var/www will can replaced with Y:/

--- a/PhpStorm Protocol (Win)/run_editor.js
+++ b/PhpStorm Protocol (Win)/run_editor.js
@@ -6,7 +6,7 @@ var settings = {
     x64: true,
 
     // Set to folder name, where PhpStorm was installed to (e.g. 'PhpStorm')
-    folder_name: 'PhpStorm 2017.1.4',
+    folder_name: '<PhpStorm x.y.z folder name where the phpstorm executable has been installed>',
 
     // Set to window title (only text after dash sign), that you see, when switching to running PhpStorm instance
     window_title: 'PhpStorm 2017.1.4',

--- a/README.md
+++ b/README.md
@@ -50,6 +50,22 @@ Installing on Windows
 4. double click on ```C:\Program Files\PhpStorm Protocol (Win)\run_editor.reg``` file
 5. agree to whatever Registry Editor asks you
 6. update settings at ```C:\Program Files\PhpStorm Protocol (Win)\run_editor.js``` file, because each PhpStorm version is installed into it's own sub-folder!
+   #### run_editor.js: 
+    ```
+    // Set to folder name, where PhpStorm was installed to (e.g. 'PhpStorm')
+    folder_name: '<phpstorm_folder_name>',
+  
+    // Set to window title (only text after dash sign), that you see, when switching to running PhpStorm instance
+    window_title: '<phpstorm_window_name>',
+    ```
+   #### updated run_editor.js
+   ```
+   // Set to folder name, where PhpStorm was installed to (e.g. 'PhpStorm')
+   folder_name: 'PhpStorm 2017.1.4',
+
+   // Set to window title (only text after dash sign), that you see, when switching to running PhpStorm instance
+   window_title: 'PhpStorm 2017.1.4',
+   ```
 7. delete cloned folder
 
 #### Working under another path?

--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ Installing on Windows
     folder_name: '<phpstorm_folder_name>',
   
     // Set to window title (only text after dash sign), that you see, when switching to running PhpStorm instance
-    window_title: '<phpstorm_window_name>',
+    window_title: '<phpstorm_window_title>',
     ```
    #### updated run_editor.js
    ```


### PR DESCRIPTION
This is to make it more clear to the end user that they will need to update the run_editor.js with the correct folder name where there PhpStorm executable is located.

Closes #32 