### PR TITLE
Fix current folder version detection on Windows

### DIFF
--- a/PhpStorm Protocol (Win)/run_editor.js
+++ b/PhpStorm Protocol (Win)/run_editor.js
@@ -86,19 +86,31 @@ function configureToolboxSettings(settings) {
     // read the maximum version from toolbox filesystem
     for (var objEnum = new Enumerator(fileCollection); !objEnum.atEnd(); objEnum.moveNext()) {
         var folderObject = ( objEnum.item() );
-        if (folderObject.Name.lastIndexOf('plugins') === -1) {
-            var versionMatch = /(\d+)\.(\d+)\.(\d+)/.exec(folderObject.Name),
-                major = parseInt(versionMatch[ 1 ]),
-                minor = parseInt(versionMatch[ 2 ]),
-                patch = parseInt(versionMatch[ 3 ]);
-            if (maxMajor === 0 || maxMajor <= major) {
-                maxMajor = major;
-                if (maxMinor === 0 || maxMinor <= minor) {
-                    maxMinor = minor;
-                    if (maxPatch === 0 || maxPatch <= patch) {
-                        maxPatch = patch;
-                        maxVersionFolder = folderObject.Name;
-                    }
+
+        if (folderObject.Name.lastIndexOf('plugins') !== -1) {
+            continue;
+        }
+
+        var versionMatch = /(\d+)\.(\d+)\.(\d+)/.exec(folderObject.Name),
+            major = parseInt(versionMatch[ 1 ]),
+            minor = parseInt(versionMatch[ 2 ]),
+            patch = parseInt(versionMatch[ 3 ]);
+
+        if (maxMajor === 0 || maxMajor <= major) {
+            if (maxMajor < major) {
+                maxMinor = 0;
+                maxPatch = 0;
+            }
+
+            if (maxMinor === 0 || maxMinor <= minor) {
+                maxMinor = minor;
+                if (maxMinor < minor) {
+                    maxPatch = 0;
+                }
+
+                if (maxPatch === 0 || maxPatch <= patch) {
+                    maxPatch = patch;
+                    maxVersionFolder = folderObject.Name;
                 }
             }
         }


### PR DESCRIPTION
Hi,
The max version detection algorithme wasn't working properly for patch element. 
This was causing an error when opening the script.

Broken edge case example: 203.5251.40 and 211.5787.18.

Thanks