### PR TITLE
[Windows] Allow open directory as project & files without specified line

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,8 @@ Following string must be specified as an editor in your app:
 phpstorm://open?url=file://%f&line=%l
 ```
 
+The **Windows version** also supports opening a directory as project and files without specified line.
+
 Alternative syntax is supported for cross-platform compatibility with PhPStorm 8+ (Mac version)
 ```bash
 phpstorm://open?file=%f&line=%l
@@ -50,11 +52,11 @@ Installing on Windows
 4. double click on ```C:\Program Files\PhpStorm Protocol (Win)\run_editor.reg``` file
 5. agree to whatever Registry Editor asks you
 6. update settings at ```C:\Program Files\PhpStorm Protocol (Win)\run_editor.js``` file, because each PhpStorm version is installed into it's own sub-folder!
-   #### run_editor.js: 
+   #### run_editor.js:
     ```
     // Set to folder name, where PhpStorm was installed to (e.g. 'PhpStorm')
     folder_name: '<phpstorm_folder_name>',
-  
+
     // Set to window title (only text after dash sign), that you see, when switching to running PhpStorm instance
     window_title: '<phpstorm_window_title>',
     ```


### PR DESCRIPTION
This change enhances the protocol handler to support additional URL schemes, allowing PhpStorm to open either a specific file, a specific file at a specified line, or an entire folder. The supported URL schemes are now:

- `phpstorm://open?url=file://C:\Users\schar\Herd\herd-website\.env&line=2` (Existing functionality to open a file at a specified line)
- `phpstorm://open?url=file://C:\Users\schar\Herd\herd-website` (Open a folder)
- `phpstorm://open?url=file://C:\Users\schar\Herd\herd-website\.env` (Open a specific file without a line number)


The changes have been tested successfully in the following environments:

- **PhpStorm 2024.1**: Build #PS-241.14494.237, built on March 27, 2024
- **PhpStorm 2024.2.0.1**: Build #PS-242.20224.427, built on August 21, 2024

Operating System: **Windows 11, 23H2**: Build 22631.4037


Let me know if you need any more info or code adjustments.

Thanks!