### PR TITLE
Windows : handle fresh toolbox install

### DIFF
--- a/PhpStorm Protocol (Win)/run_editor.js
+++ b/PhpStorm Protocol (Win)/run_editor.js
@@ -132,7 +132,7 @@ function getFavoritePhpStormChannel() {
     var settings = JSON.parse(fileStream.ReadAll());
     fileStream.Close()
 
-    var apps = settings.ordering.local || [];
+    var apps = (settings.ordering || {}).local || [];
     for (var i = 0; i < apps.length; i++) {
         if (apps[i].application_id == 'PhpStorm') {
             return apps[i].channel_id;


### PR DESCRIPTION
Hi,
On fresh Toolbox install, when there is only one app installed, the ordering key is missing.
Regards,
Karel