### PR TITLE
Simplify installation instructions for JetBrains ToolBox

### DIFF
--- a/PhpStorm Protocol (Win)/run_editor.js
+++ b/PhpStorm Protocol (Win)/run_editor.js
@@ -5,10 +5,10 @@ var settings = {
     // Set to disk letter, where PhpStorm was installed to (e.g. C:)
     disk_letter: 'C:',
 
-    // Set to folder name, where PhpStorm was installed to (e.g. 'PhpStorm')
+    // [Change only, when not using JetBrains Toolbox] Set to folder name, where PhpStorm was installed to (e.g. 'PhpStorm')
     folder_name: '<phpstorm_folder_name>',
 
-    // Set to window title (only text after dash sign), that you see, when switching to running PhpStorm instance
+    // [Change only, when not using JetBrains Toolbox] Set to window title (only text after dash sign), that you see, when switching to running PhpStorm instance
     window_title: '<phpstorm_window_title>',
 
     // In case your file is mapped via a network share and paths do not match.

--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ Installing on Windows
 3. copy folder ```PhpStorm Protocol (Win)``` to ```C:\Program Files\``` folder
 4. double click on ```C:\Program Files\PhpStorm Protocol (Win)\run_editor.reg``` file
 5. agree to whatever Registry Editor asks you
-6. update settings at ```C:\Program Files\PhpStorm Protocol (Win)\run_editor.js``` file, because each PhpStorm version is installed into it's own sub-folder!
+6. **(only, when not using JetBrains ToolBox)** update settings at ```C:\Program Files\PhpStorm Protocol (Win)\run_editor.js``` file, because each PhpStorm version is installed into it's own sub-folder!
    #### run_editor.js:
     ```
     // Set to folder name, where PhpStorm was installed to (e.g. 'PhpStorm')


### PR DESCRIPTION
Updated installation instructions to prevent any confusion for JetBrains ToolBox users.

Current installation instructions ask to change `settings.folder_name` and `settings.window_name`, but this is only required when JetBrains ToolBox isn't in use.