### PR TITLE
Windows: support Toolbox launchCommand with full path

### DIFF
--- a/PhpStorm Protocol (Win)/run_editor.js
+++ b/PhpStorm Protocol (Win)/run_editor.js
@@ -120,7 +120,9 @@ function getPhpStormCommandPath() {
     var tools = state.tools || [];
     for (var i = 0; i < tools.length; i++) {
         if (tools[i].toolId == 'PhpStorm') {
-            return tools[i].installLocation + '\\' + tools[i].launchCommand.replace(/\//g, '\\');
+            var basePath = tools[i].launchCommand.indexOf(tools[i].installLocation) === -1 ? tools[i].installLocation +  "\\" : "";
+
+            return (basePath + tools[i].launchCommand).replace(/\//g, "\\");
         }
     }
 


### PR DESCRIPTION
Hi,

In the latest version of Toolbox, the state.json file that contains PHPStorm executable command format changed. It now contains the full path.

```js
{
    "version": 1,
    "appVersion": "2.6.2.41321",
    "tools": [
        {
            "channelId": "4a8366ba-e564-4a14-9b2e-eca07ac47f93",
            "toolId": "PhpStorm",
            "productCode": "PS",
            "tag": "php-storm",
            "displayName": "PhpStorm",
            "displayVersion": "2025.1.0.1",
            "buildNumber": "251.23774.466",
            "installLocation": "C:\\Users\\XXX\\AppData\\Local\\Programs\\PhpStorm 2",
            "launchCommand": "C:\\Users\\XXX\\AppData\\Local\\Programs\\PhpStorm 2\\bin\\phpstorm64.exe"
        },
    ]
}
```

This PR allows to only use the `launchCommand` path when it's full.

Regards