### PR TITLE
[Windows] Projects without ".idea\.name" file wasn't auto-opened in the PhpStorm 2026.2

### DIFF
--- a/PhpStorm Protocol (Win)/run_editor.js
+++ b/PhpStorm Protocol (Win)/run_editor.js
@@ -62,7 +62,6 @@ if (match) {
         while (search_path.lastIndexOf('\\') !== -1) {
             search_path = search_path.substring(0, search_path.lastIndexOf('\\'));
 
-            // The .idea/.name file is not always present, look for the .idea folder instead.
             if (file_system.FolderExists(search_path + '\\.idea')) {
                 project = search_path;
                 break;

--- a/PhpStorm Protocol (Win)/run_editor.js
+++ b/PhpStorm Protocol (Win)/run_editor.js
@@ -62,7 +62,8 @@ if (match) {
         while (search_path.lastIndexOf('\\') !== -1) {
             search_path = search_path.substring(0, search_path.lastIndexOf('\\'));
 
-            if (file_system.FileExists(search_path + '\\.idea\\.name')) {
+            // The .idea/.name file is not always present, look for the .idea folder instead.
+            if (file_system.FolderExists(search_path + '\\.idea')) {
                 project = search_path;
                 break;
             }


### PR DESCRIPTION
PhpStorm 2026.2 broke the Windows protocol handler in two ways:

- `--line` is now ignored unless the project path is passed as an argument. The project is detected by walking up from the file, but it looked for the `.idea/.name` file which is no longer always present. It now looks for the `.idea` folder instead.
- `shell.Exec` does not launch the Toolbox `.cmd` wrapper properly, so PhpStorm never opened. Switched to `shell.Run`.

Tested on Windows 11 with Toolbox 3.6.2 and PhpStorm 2026.2.0.1.