### PR TITLE
[Windows] Remove non-functional window_title/AppActivate window-focus workaround

### DIFF
--- a/PhpStorm Protocol (Win)/run_editor.js
+++ b/PhpStorm Protocol (Win)/run_editor.js
@@ -8,9 +8,6 @@ var settings = {
     // (only, when not using JetBrains Toolbox) Set to folder name, where PhpStorm was installed to (e.g. 'PhpStorm')
     folder_name: '<phpstorm_folder_name>',
 
-    // (only, when not using JetBrains Toolbox) Set to window title (only text after dash sign), that you see, when switching to running PhpStorm instance
-    window_title: '<phpstorm_window_title>',
-
     // In case your file is mapped via a network share and paths do not match.
     // eg. /var/www will can replaced with Y:/
     projects_basepath: '',
@@ -85,7 +82,6 @@ if (match) {
         .replace(/\//g, '\\');
 
     shell.Exec(command);
-    shell.AppActivate(settings.window_title);
 }
 
 function isToolboxInstalled() {
@@ -221,10 +217,9 @@ function configureToolboxSettings(settings) {
 
     settings.folder_name = maxVersionFolder;
 
-    // read version name and product name from product-info.json
+    // read launcher path from product-info.json
     var versionFile = fso.OpenTextFile(toolboxDirectory + settings.folder_name + "\\product-info.json", 1, true);
     var productVersion = JSON.parse(versionFile.ReadAll());
-    settings.window_title = 'PhpStorm ' + productVersion.version;
     editor = '"' + toolboxDirectory + settings.folder_name + '\\' + productVersion.launch[ 0 ].launcherPath.replace(/\//g, '\\') + '"';
 }
 

--- a/README.md
+++ b/README.md
@@ -85,17 +85,11 @@ Installing on Windows
     ```js
     // Set to folder name, where PhpStorm was installed to (e.g. 'PhpStorm')
     folder_name: '<phpstorm_folder_name>',
-
-    // Set to window title (only text after dash sign), that you see, when switching to running PhpStorm instance
-    window_title: '<phpstorm_window_title>',
     ```
    #### updated run_editor.js
    ```js
    // Set to folder name, where PhpStorm was installed to (e.g. 'PhpStorm')
    folder_name: 'PhpStorm 2017.1.4',
-
-   // Set to window title (only text after dash sign), that you see, when switching to running PhpStorm instance
-   window_title: 'PhpStorm 2017.1.4',
    ```
 
 #### Working under another path?


### PR DESCRIPTION
## Summary

`run_editor.js` (Windows protocol handler) has always called `shell.AppActivate(settings.window_title)`
after launching PhpStorm, going back to the very first Windows implementation in 2013 — years before
JetBrains Toolbox existed. Testing on Windows 11 (ARM) with PhpStorm 2026.1.4 and 2026.2.0.1 shows this
is unnecessary and non-functional today:

- PhpStorm's own single-instance launch behavior already brings the correct window to the foreground
  on its own, whether launched via a direct install, Toolbox's generated shell script, or a `state.json`-
  resolved exe path — confirmed across all three `getPhpStormCommandPath()` resolution branches.
- `window_title` was documented as "the text after the dash sign" in the window title (e.g.
  "file.php - PhpStorm 2026.2"). On current PhpStorm builds, the window title no longer contains a
  product-name suffix at all (confirmed via the real Win32 window text, not just visual inspection),
  so this setting can never be configured to match anything.
- Separately, `shell.AppActivate` reported success (`true`) even when it demonstrably did not change
  the actual foreground window, confirming it's an unreliable mechanism for stealing focus from an
  external script on modern Windows regardless of the title value.

## Changes

- Removed the `window_title` setting from `run_editor.js` and the `shell.AppActivate(...)` call.
- Removed the corresponding `window_title` assignment in `configureToolboxSettings()`'s legacy
  (pre-Toolbox-2.0) fallback path.
- Removed the `window_title` example/instructions from README.md.

## Tested on

Windows 11 (ARM), PhpStorm 2026.1.4 and 2026.2.0.1, covering:
- Direct install (no Toolbox)
- Toolbox-generated shell script (`scripts\PhpStorm.cmd`)
- Toolbox `state.json` direct-parse resolution (shell script temporarily removed to force this path)

In every case, the target window came to focus at the correct file/line with no `AppActivate` call at all.