### PR TITLE
Update CLAUDE.md with Toolbox v1/v2/v3 findings

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -43,10 +43,10 @@ by manually running the install flow on the target OS.
   documentation and is written per-OS (Windows/Mac/Linux sections).
 - Naming: Toolbox-related functions are prefixed `toolbox_v1_` (legacy folder-scan only) or
   `toolbox_common_` (works across all tested Toolbox generations). Keep this convention for new code.
-- Known unfixed gap: `getPhpStormCommandPath`'s `state.json` branch picks the first `toolId ==
-  'PhpStorm'` entry, ignoring `settings.toolbox_update_channel_dir` — multi-channel Toolbox 2.0+/3.x
-  installs may launch the wrong version. `channels\` there holds per-channel JSON *files*, not
-  folders.
+- `getPhpStormCommandPath`'s `state.json` branch matches `settings.toolbox_update_channel_dir`
+  against each entry's `channelId` (substring, since the shape varies by Toolbox version) to pick
+  among multiple installed channels; `null` keeps the old first-match default. `channels\` there
+  holds per-channel JSON *files*, not folders.
 
 ## Backward-compatibility promise — the core design constraint
 
@@ -80,7 +80,8 @@ not new features. Expect this to continue.
   (auto-detect) → #48 (favorite channel) → #50 (2023, `state.json` — **broke v1 support**, see BC
   section) → #54 (fresh install) → #58/#59 (prefer shell script) → #66 (2025, absolute
   `launchCommand`) → #69 (2026, `.idea` folder vs `.idea/.name` detection fix) → #72 (2026, restored
-  v1 support broken by #50).
+  v1 support broken by #50) → #74 (2026, honor `toolbox_update_channel_dir` in the `state.json` path,
+  which #50 never wired up).
 - #71 (2026): removed non-functional `window_title`/`AppActivate`.
 - Windows/registry quirks: #21/#25/#26/#28, `Icon\r` removal (`cc2fd3b`).
 - PhpStorm version drift: #8/#11/#16 (default folder-name bumps for direct installs).

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -19,10 +19,10 @@ by manually running the install flow on the target OS.
   bundled here; it defers to an external AUR package / `sanduhrs/phpstorm-url-handler`).
 - `LinCastor.md` — Mac fallback doc for configuring the third-party LinCastor app on OS X 10.9+.
 - `PhpStorm Protocol (Win)/` — Windows installer, copied to `C:\Program Files\`:
-  - `run_editor.js` — JScript run via `wscript` on protocol invocation. Parses the `phpstorm://` URL
-    with a regex, resolves the PhpStorm executable (either a directly configured disk/folder, or
-    auto-detected via JetBrains Toolbox's `state.json`/`.settings.json`/`product-info.json`), and
-    launches/focuses PhpStorm at the file:line via `WScript.Shell.Exec` + `AppActivate`.
+  - `run_editor.js` — parses `phpstorm://` URL, resolves PhpStorm exe via `getPhpStormCommandPath()`
+    priority chain (`settings.toolbox_v1_commandPath` → shell script → `state.json` → standalone
+    fallback), launches via `shell.Exec`. No `AppActivate`/window-focus step (removed in #71 —
+    PhpStorm self-focuses regardless of launch path; the old code never worked anyway).
   - `json2.js` — vendored JSON polyfill, included by `run_editor.js`.
   - `run_editor.reg` — installs the `HKEY_CLASSES_ROOT\phpstorm` registry key pointing at
     `run_editor.js`.
@@ -41,6 +41,12 @@ by manually running the install flow on the target OS.
   compiled AppleScript binary and is not meant to be hand-edited as text.
 - When changing install/uninstall behavior, keep `README.md` in sync — it is the only end-user
   documentation and is written per-OS (Windows/Mac/Linux sections).
+- Naming: Toolbox-related functions are prefixed `toolbox_v1_` (legacy folder-scan only) or
+  `toolbox_common_` (works across all tested Toolbox generations). Keep this convention for new code.
+- Known unfixed gap: `getPhpStormCommandPath`'s `state.json` branch picks the first `toolId ==
+  'PhpStorm'` entry, ignoring `settings.toolbox_update_channel_dir` — multi-channel Toolbox 2.0+/3.x
+  installs may launch the wrong version. `channels\` there holds per-channel JSON *files*, not
+  folders.
 
 ## Backward-compatibility promise — the core design constraint
 
@@ -50,62 +56,37 @@ release to release. What *does* change, constantly and outside this project's co
 detection layer underneath it: how to locate/launch the right PhpStorm executable given whatever
 version of Windows, PhpStorm, and JetBrains Toolbox the user happens to have installed.
 
-Users cannot always upgrade their OS/PhpStorm/Toolbox in lockstep with this repo. So a new
-PhpStormProtocol release must keep working for someone still on an old Toolbox 1.x layout or a
-directly-installed PhpStorm, not just for whoever triggered the latest fix. Concretely, when patching
-`run_editor.js`'s detection logic (`getPhpStormCommandPath`, `getFavoritePhpStormChannel`,
-`configureToolboxSettings`, project detection, etc.):
+Users cannot upgrade OS/PhpStorm/Toolbox in lockstep with this repo. When patching detection logic
+(`getPhpStormCommandPath`, `toolbox_v1_*`, `toolbox_common_*`, project detection):
 
-- **Add a fallback branch, don't replace the old code path.** Every historical Toolbox-format change
-  (PR #30 → #50 → #66 → #69) was handled by detecting the new layout first and falling back to the
-  previous logic if it's absent — never by assuming the new layout is the only one that exists.
-- Detect format/version by **probing for what's actually present on disk** (does `state.json` exist?
-  does `apps/` exist? is `launchCommand` absolute or relative?), not by assuming a single supported
-  target version.
-- Don't drop support for standalone (non-Toolbox) PhpStorm installs when fixing a Toolbox-specific
-  issue, and vice versa.
-- When PhpStorm's own CLI behavior changes (e.g. PR #69's `--line`-requires-project-path-first-arg
-  change), branch on it rather than making the new calling convention unconditional, if there's any
-  chance older PhpStorm versions relied on the old one.
+- **Add a fallback branch; never let a new path silently replace an old one's result.** PR #50
+  (784f1b6) added `state.json` support but broke Toolbox 1.x support in the process: it moved a
+  shared `editor` assignment to run after the v1 scan, unconditionally overwriting it, and its own
+  fallback formula assumed the wrong install location. Silently broken for ~2 years, unnoticed
+  because most users hit the shell-script path instead. Fixed in #72 by giving v1's result its own
+  dedicated field (`settings.toolbox_v1_commandPath`) instead of sharing state. **Don't reuse/share
+  variables across resolution paths — that's exactly what caused this regression.**
+- Detect format/version by **probing what's actually on disk**, not assuming one target version.
+- Don't drop standalone-install support when fixing Toolbox, or vice versa.
+- If PhpStorm's own CLI behavior changes (e.g. #69: `--line` needs project path first), branch on it —
+  don't assume the new calling convention unconditionally.
 
-## PR history: this is mostly a reactive-maintenance repo
+## PR history: reactive-maintenance repo
 
-Looking at the GitHub PR/commit history (80 commits, ~50 merged PRs since 2013), the large majority of
-substantive changes are **not new features** — they are fixes for `run_editor.js` (Windows) breaking
-because JetBrains Toolbox, PhpStorm itself, or Windows changed how they lay out install paths/config.
-Expect this pattern to continue, and treat "PhpStorm/Toolbox changed something again" as the default
-reason for a bug report, not an edge case:
+Most substantive changes are fixes for Toolbox/PhpStorm/Windows breaking install-path assumptions,
+not new features. Expect this to continue.
 
-- **JetBrains Toolbox storage/layout changes**, repeatedly, as Toolbox evolved:
-  - PR #30 (2019) — initial Toolbox support (`apps/` folder + `.settings.json`).
-  - PR #36/#37 (2021) — "fix current/really fix folder version detection on Windows" (Toolbox's
-    version-folder naming changed).
-  - PR #38 (2021) — auto-detect whether Toolbox is installed at all.
-  - PR #48 (2023) — read favorite PhpStorm channel from Toolbox settings.
-  - PR #50 (2023) — "Add support to new Toolbox storage engine" (Toolbox introduced a new state
-    format).
-  - PR #54 (2024) — handle a fresh Toolbox install (no prior state yet).
-  - PR #58/#59 (2024) — prefer Toolbox's own generated shell script launcher over reimplementing
-    path resolution.
-  - PR #66 (2025, merged) — Toolbox's `launchCommand` started including a full path instead of a
-    relative one.
-  - **PR #69 (2026-07-24, open)** — Toolbox 2.0+ removed the `apps/` directory entirely (IDEs now
-    under `%localappdata%\Programs\PhpStorm\`, with an absolute `launchCommand` in `state.json`), and
-    PhpStorm 2026.2+ started silently ignoring `--line` unless the project path is passed as the
-    first CLI argument. Fixes `getPhpStormCommandPath`, `getFavoritePhpStormChannel`,
-    `configureToolboxSettings`, project detection (`.idea/` folder vs `.idea/.name` file), and
-    switches the launcher from `shell.Exec` to `shell.Run`.
-- **Windows OS/registry quirks**: PR #21/#25/#26 (Windows 10 / x64 registry-key fixes), PR #28 ("total
-  compatibility x64 windows"), the `Icon\r` file removal (commit `cc2fd3b`) that was breaking Windows
-  file listings.
-- **PhpStorm CLI/versioning drift**: recurring "update default settings for current PhpStorm version"
-  PRs (#8, #11, #16) whenever a new PhpStorm version changed its default install folder name.
-- Genuinely new-feature PRs are the minority: Linux instructions (#17), Mac scheme support (#22),
-  project-folder-without-line-number support (#52/#53), configurable disk letter (#41), configurable
-  Toolbox shell-script path (#58/#59), and the uninstall.reg addition (#65, this branch).
+- Toolbox layout changes: #30 (2019, initial support) → #36/#37 (version-folder detection) → #38
+  (auto-detect) → #48 (favorite channel) → #50 (2023, `state.json` — **broke v1 support**, see BC
+  section) → #54 (fresh install) → #58/#59 (prefer shell script) → #66 (2025, absolute
+  `launchCommand`) → #69 (2026, `.idea` folder vs `.idea/.name` detection fix, open) → #72 (2026,
+  restored v1 support broken by #50, open).
+- #71 (2026, merged): removed non-functional `window_title`/`AppActivate`.
+- Windows/registry quirks: #21/#25/#26/#28, `Icon\r` removal (`cc2fd3b`).
+- PhpStorm version drift: #8/#11/#16 (default folder-name bumps for direct installs).
+- Minority are real new features: #17 (Linux docs), #22 (Mac scheme), #52/#53 (no-line-number
+  support), #41 (disk letter config), #58/#59 (shell-script config), #65 (uninstall.reg).
 
-**Implication for future work**: when a user reports "phpstorm:// stopped working" after updating
-Toolbox, PhpStorm, or Windows, the fix almost always belongs in `run_editor.js`'s Toolbox-path/
-version-detection or CLI-argument logic (see `getPhpStormCommandPath`, `getFavoritePhpStormChannel`,
-`configureToolboxSettings` per PR #69) — check `gh pr list --repo aik099/PhpStormProtocol` and the
-currently open PRs for known unmerged fixes before re-deriving the same investigation.
+**When a user reports breakage** after a Toolbox/PhpStorm/Windows update: check
+`gh pr list --repo aik099/PhpStormProtocol` for known unmerged fixes first, then look at
+`getPhpStormCommandPath`'s priority chain and `toolbox_v1_*`/`toolbox_common_*` functions.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -79,9 +79,9 @@ not new features. Expect this to continue.
 - Toolbox layout changes: #30 (2019, initial support) → #36/#37 (version-folder detection) → #38
   (auto-detect) → #48 (favorite channel) → #50 (2023, `state.json` — **broke v1 support**, see BC
   section) → #54 (fresh install) → #58/#59 (prefer shell script) → #66 (2025, absolute
-  `launchCommand`) → #69 (2026, `.idea` folder vs `.idea/.name` detection fix, open) → #72 (2026,
-  restored v1 support broken by #50, open).
-- #71 (2026, merged): removed non-functional `window_title`/`AppActivate`.
+  `launchCommand`) → #69 (2026, `.idea` folder vs `.idea/.name` detection fix) → #72 (2026, restored
+  v1 support broken by #50).
+- #71 (2026): removed non-functional `window_title`/`AppActivate`.
 - Windows/registry quirks: #21/#25/#26/#28, `Icon\r` removal (`cc2fd3b`).
 - PhpStorm version drift: #8/#11/#16 (default folder-name bumps for direct installs).
 - Minority are real new features: #17 (Linux docs), #22 (Mac scheme), #52/#53 (no-line-number


### PR DESCRIPTION
## Summary

Updates CLAUDE.md with findings from investigating Toolbox v1/v2/v3 detection behavior:

- Corrects a factual error: PR #50 was cited as a good example of preserving fallback behavior when
  adding new detection logic. It actually did the opposite — it broke Toolbox 1.x support in the
  process (fixed in #72).
- Documents the `toolbox_v1_`/`toolbox_common_` naming convention introduced in #72.
- Documents how the `state.json` resolution path now honors `toolbox_update_channel_dir` for
  multi-channel Toolbox 2.0+/3.x installs (#74).
- Trims/tightens prose throughout (this file is for Claude Code's own reference, not human reading).

Independent of the code-fix PRs (#72, #74) — intentionally not merged together, per
small-focused-PRs convention already used in this repo.

Documentation only — no behavioral changes.