### PR TITLE
Document tested Toolbox/PhpStorm version coverage

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -40,7 +40,8 @@ by manually running the install flow on the target OS.
 - Mac logic lives in `Contents/bin/parse_url.sh` (plain shell, easy to edit) — `main.scpt` is a
   compiled AppleScript binary and is not meant to be hand-edited as text.
 - When changing install/uninstall behavior, keep `README.md` in sync — it is the only end-user
-  documentation and is written per-OS (Windows/Mac/Linux sections).
+  documentation and is written per-OS (Windows/Mac/Linux sections). Its Windows "Compatibility"
+  section lists tested Toolbox/PhpStorm versions — update it when that coverage changes.
 - Naming: Toolbox-related functions are prefixed `toolbox_v1_` (legacy folder-scan only) or
   `toolbox_common_` (works across all tested Toolbox generations). Keep this convention for new code.
 - `getPhpStormCommandPath`'s `state.json` branch matches `settings.toolbox_update_channel_dir`

--- a/README.md
+++ b/README.md
@@ -47,6 +47,15 @@ PhpStorm 8+ (Mac version only) has built-in url handler and `phpstorm://open?fil
 Installing on Windows
 =====================
 
+## Compatibility
+
+Works with a direct (standalone) PhpStorm install, or with PhpStorm installed/managed through
+JetBrains Toolbox — legacy Toolbox 1.x and current Toolbox 2.0+/3.x are both supported, including
+selecting a specific installed channel/version when more than one is present.
+
+Tested with Toolbox 1.28.2, 2.9.1, and 3.6.2, and PhpStorm 2025.2, 2026.1.4, and 2026.2.0.1, on
+Windows 11 (ARM).
+
 ## Downloading & Installation
 
 1. clone this repository


### PR DESCRIPTION
## Summary

- README: adds a Compatibility section to the Windows install docs, covering direct installs and
  Toolbox 1.x/2.0+/3.x support (including channel/version selection), with the specific versions
  tested this session (Toolbox 1.28.2/2.9.1/3.6.2, PhpStorm 2025.2/2026.1.4/2026.2.0.1, Windows 11 ARM).
- CLAUDE.md: notes that this section needs updating when tested coverage changes.

Documentation only — no behavioral changes.