### PR TITLE
Untangle defaultCommandPath if/else in run_editor.js

### DIFF
--- a/PhpStorm Protocol (Win)/run_editor.js
+++ b/PhpStorm Protocol (Win)/run_editor.js
@@ -115,7 +115,18 @@ function getPhpStormCommandPath() {
     }
 
     var settingsStateFile = appDataLocal + '\\JetBrains\\Toolbox\\state.json',
-        defaultCommandPath = settings.disk_letter + '\\' + ( settings.x64 ? 'Program Files' : 'Program Files (x86)' ) + '\\JetBrains\\' + settings.folder_name + ( settings.x64 ? '\\bin\\phpstorm64.exe' : '\\bin\\phpstorm.exe' );
+        programFilesFolder,
+        executableName;
+
+    if (settings.x64) {
+        programFilesFolder = settings.disk_letter + '\\Program Files';
+        executableName = '\\bin\\phpstorm64.exe';
+    } else {
+        programFilesFolder = settings.disk_letter + '\\Program Files (x86)';
+        executableName = '\\bin\\phpstorm.exe';
+    }
+
+    var defaultCommandPath = programFilesFolder + '\\JetBrains\\' + settings.folder_name + executableName;
 
     try {
         var fileStream = (new ActiveXObject('Scripting.FileSystemObject')).OpenTextFile(settingsStateFile, 1, false);

--- a/README.md
+++ b/README.md
@@ -101,6 +101,13 @@ Windows 11 (ARM).
    folder_name: 'PhpStorm 2017.1.4',
    ```
 
+* On some systems the installed `phpstorm64.exe`/`phpstorm.exe` doesn't match the `x64` setting's
+  assumed `Program Files`/`Program Files (x86)` folder — e.g. [#56](https://github.com/aik099/PhpStormProtocol/issues/56)
+  reports a 64-bit `phpstorm64.exe` installed under `Program Files (x86)`. If the executable isn't
+  found, check where PhpStorm actually installed and hand-adjust the `programFilesFolder`/
+  `executableName` values built in `getPhpStormCommandPath()` (`run_editor.js`) to match, rather than
+  relying on the `x64` setting alone.
+
 #### Working under another path?
 
 * You can make use of the [project alias settings](https://github.com/aik099/PhpStormProtocol/blob/master/PhpStorm%20Protocol%20(Win)/run_editor.js#L14-L17) in case you are working under a network share or Vagrant.


### PR DESCRIPTION
## Summary
- Replaces the nested ternary building `defaultCommandPath` in `getPhpStormCommandPath()` with named `programFilesFolder`/`executableName` variables set via if/else, for readability. No behavior change — verified by hand for both `x64` true/false branches.
- Adds a README note (standalone-install section) that some setups don't follow the `x64` → Program Files (x86 vs 64-bit) assumption — see #56, where a 64-bit `phpstorm64.exe` was installed under `Program Files (x86)` — and that users may need to hand-adjust `programFilesFolder`/`executableName` in that case.

## Test plan
- [x] Traced both `x64` boolean branches by hand against the original ternary expression to confirm identical output strings
- [ ] No automated test suite in this repo (per CLAUDE.md); manual verification on Windows recommended before merge