### PR TITLE
[Windows] Fix "url=file://" links pointing to a Windows path

### DIFF
--- a/PhpStorm Protocol (Win)/run_editor.js
+++ b/PhpStorm Protocol (Win)/run_editor.js
@@ -38,7 +38,9 @@ if (toolbox_v1_isInstalled()) {
 if (match) {
     var shell = new ActiveXObject('WScript.Shell'),
         file_system = new ActiveXObject('Scripting.FileSystemObject'),
-        file = decodeURIComponent(match[ 2 ]).replace(/\+/g, ' '),
+        // "url=file://%f" with a Windows path decodes to "/C:/...", and that leading slash makes the
+        // path unusable.
+        file = decodeURIComponent(match[ 2 ]).replace(/\+/g, ' ').replace(/^[\\\/]([A-Za-z]:)/, '$1'),
         search_path = file.replace(/\//g, '\\'),
         editor = '"' + getPhpStormCommandPath() + '"';
 


### PR DESCRIPTION
Hi,

A `url=file://%f` link pointing to a Windows path decodes to `/C:/path/to/file.php`. The leading slash was kept, so the script looked for `\C:\path\to\file.php`: the project was never detected and PhpStorm got a path it could not open.

That is what #40 reports, with `W:/index.php` ending up as `C:\Windows\system32\W`.

Before:

```
"PhpStorm.cmd" --line 5 "\C:\path\to\composer.json"
```

After:

```
"PhpStorm.cmd" "C:\path\to\project" --line 5 "C:\path\to\composer.json"
```

The slash is only removed when it sits right before a drive letter, so the `file=%f` form and Unix paths are untouched.

Tested on Windows 11 with Toolbox 3.6.3 and PhpStorm 2026.2.0.1, with both URL forms: file with a line number, file without one, and directory.

Closes #40

Regards,
Karel
