### PR TITLE
[Windows] Fix project detection when "projects_path_alias" is used

### DIFF
--- a/PhpStorm Protocol (Win)/run_editor.js
+++ b/PhpStorm Protocol (Win)/run_editor.js
@@ -39,12 +39,13 @@ if (match) {
     var shell = new ActiveXObject('WScript.Shell'),
         file_system = new ActiveXObject('Scripting.FileSystemObject'),
         file = decodeURIComponent(match[ 2 ]).replace(/\+/g, ' '),
-        search_path = file.replace(/\//g, '\\'),
         editor = '"' + getPhpStormCommandPath() + '"';
 
     if (settings.projects_basepath !== '' && settings.projects_path_alias !== '') {
         file = file.replace(new RegExp('^' + settings.projects_basepath), settings.projects_path_alias);
     }
+
+    var search_path = file.replace(/\//g, '\\');
 
     // If only a folder is specified, don't look for a project file or line number
     var isFolder = file_system.FolderExists(search_path);


### PR DESCRIPTION
Hi,

`search_path` is computed before `projects_path_alias` rewrites `file`, and never updated afterwards, so the existence checks run on the path the alias just replaced:

```js
search_path = file.replace(/\//g, '\\'),
...
file = file.replace(new RegExp('^' + settings.projects_basepath), settings.projects_path_alias);
```

`isFile`/`isFolder` stay false and the walk-up looking for `.idea` never runs, so no project path is passed. A file link then opens at the wrong line since PhpStorm 2026.2 ignores `--line` without it (same cause as #69), and a directory link gets no path at all, so nothing opens.

Fix is to run that same line again once `file` is final. The `/` to `\` conversion is needed, not a plain copy: aliases are written like `Y:/` and the walk-up uses `lastIndexOf('\\')`.

Not a recent regression, 5355a08 introduced this ordering in 2015. Both settings are empty by default.

Tested on Windows 11 with Toolbox 3.6.3 and PhpStorm 2026.2.0.1.

Regards,
Karel
